### PR TITLE
Fix lib.rs typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The SVD files are from <https://mcuxpresso.nxp.com> and licensed under the [BSD-
 [build-link]: https://circleci.com/gh/nickray/lpc55s6x-pac/tree/main
 [docs-image]: https://docs.rs/lpc55s6x-pac/badge.svg
 [docs-link]: https://docs.rs/lpc55s6x-pac
-[lpc55s6x-hal]: https://libs.rs/lpc55s6x-hal
+[lpc55s6x-hal]: https://lib.rs/lpc55s6x-hal
 [svd-docs-link]: https://docs.rs/svd2rust
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
 [apache2-link]: https://spdx.org/licenses/Apache-2.0.html


### PR DESCRIPTION
Noticed this link 404ed, neighboring docs.rs is plural so I think that's what happened.

cc @mathias-arm